### PR TITLE
Chapter4-02 Queueを使って処理を非同期にする

### DIFF
--- a/app/Jobs/SampleJob.php
+++ b/app/Jobs/SampleJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SampleJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        echo 'Jobを実行しました。';
+    }
+}

--- a/app/Mail/NewUserIntroduction.php
+++ b/app/Mail/NewUserIntroduction.php
@@ -10,7 +10,7 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class NewUserIntroduction extends Mailable
+class NewUserIntroduction extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 

--- a/database/migrations/2023_12_31_065927_create_jobs_table.php
+++ b/database/migrations/2023_12_31_065927_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+};


### PR DESCRIPTION
1. Queueを使った非同期処理
  Webアクセスで処理を行うとき，処理が大きくなるとレスポンスが悪くなる
  そのときは非同期処理で処理を行う(ユーザの操作と処理の分離)
  非同期処理を行う際に便利なのがQueue
  Queueに処理をJobという形で積んでいき，積まれたものから順に処理される(FIFO)
  Queueには再実行な設定や失敗したJobだけを積む機能などもある
    
    - Jobクラス
      LaravelではQueueで実行されるタスク一つの単位をJobという
      Jobの実装には`Job`クラスを使う
      `Job`クラスに非同期に実行したい処理を記述する
      - ［`artisan`コマンド］ `make:job`
        `artisan make:job SampleJob`
      - `app/Jobs/SampleJob.php`
        ```php
        <?php
        
        namespace App\Jobs;

        use Illuminate\Bus\Queueable;
        use Illuminate\Contracts\Queue\ShouldBeUnique;
        use Illuminate\Contracts\Queue\ShouldQueue;
        use Illuminate\Foundation\Bus\Dispatchable;
        use Illuminate\Queue\InteractsWithQueue;
        use Illuminate\Queue\SerializesModels;

        class SampleJob implements ShouldQueue
        {
          use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

          /**
           * Create a new job instance.
           * 
           * @return void
           */
          public function __construct()
          {
            //
          }

          /**
           * Execute the job.
           * 
           * @return void
           */
          public function handle()
          {
            echo 'Jobを実行しました。';
          }
        }
        ```
      - ［`artisan`コマンド］ `tinker`
        `artisan tinker`
        `tinker`はArtisanで提供されているLaravelのREPL(Read Eval Print Loop)
        PHPのコードをコマンド入力で評価してくれる対話式シェル
      - `\Bus::dispatchSync(new App\Jobs\SampleJob());`
        ```plain
        >>> \Bus::dispatchSync(new App\Jobs\SampleJob());
        Jobを実行しました。
        => 0
        ```
        `\Bus::dispatchSync`はTinker上でJobを即時実行する際に使用するメソッド
        したがって，今のままでは非同期処理になっていない

1. Queueを使ってJobクラスを実行する
   JobクラスをQueueの機能を経由して実行する
    - Queueの設定
      Queueの設定は`config/queue.php`にある
      `config/queue.php`
      ```php
      <?php
      
      return [
        /*
         |------------------------------------------
         | Default Queue Connection Name
         |------------------------------------------
         | ...
         */
        'default' => env('QUEUE_CONNECTION', 'sync'),

        /*
         |------------------------------------------
         | Queue Connections
         |------------------------------------------
         | ...
         */
        'connections' => [
          'sync' => [
            'driver' => 'sync',
          ],
          'database' => [
            'driver' => 'database',
            'table' => 'jobs',
            'queue' => 'default',
            'retry_after' => 90,
            'after_commit' => false,
          ],
          'beanstalkd' => [
            'driver' => 'beanstalkd',
            // ...
          ],
          'sqs' => [
            'driver' => 'sqs',
            // ...
          ],
          'redis' => [
            'driver' => 'redis',
            // ...
          ],
        ],

        /*
         |------------------------------------------
         | Failed Queue Jobs
         |------------------------------------------
         | ...
         */
        'failed' => [
          'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
          'database' => env('DB_CONNECTION', 'mysql'),
          'table' => 'failed_jobs',
        ],
      ]
      ```

      `default => env('QUEUE_CONNECTION', 'sync')`は

        - `.env`ファイルに記述があればそれを利用し，
        - 記述がなければ`QUEUE_CONNECTION`を`sync`に設定する

      という意味

      今回は`.env`ファイルの`QUEUE_CONNECTION`を`database`に変更する
      `.env`
      ```ini
      # ...
      QUEUE_CONNECTION=database
      # ...
      ```

      次に，Queueに積まれたJobを管理するためのテーブルを作成する
      - ［`artisan`コマンド］ `queue:table`
        `artisan queue:table`
        このコマンドでマイグレーションファイルが生成される
      - ［`artisan`コマンド］ `migrate`
        `artisan migrate`
        これによりテータベースにjobsテーブルが追加される

    - Queueを使ってみる
      `tinker`を使ってJobを実行してみる
      - `\Bus::dispatch(new App\Jobs\SampleJobs())`
        ```plain
        >>> \Bus::dispatch(new App\Jobs\SampleJob());
        => 1
        ```
        JobがQueuqに追加されたが，実行はされていない
      - データベースの確認
        ```plain
        mysql > SELECT * FROM jobs;
        +----+---------+-----------------------------
        | id | queue   | playload
        +----+---------+-----------------------------
        |  1 | default | { "uuid": "...", .... }
        ```
        Jobが`jobs`テーブルに登録されている
      - ［`artisan`コマンド］ `queue:work`
        `artisan queue:work`
        QueueにあるJobを実行する
        ```plain
        $ artisan queue:work
        [YYYY-MM-DD hh:mm:ss][1] Processing: App\Jobs\SampleJob
        Jobを実行しました。[YYYY-MM-DD hh:mm:ss][1] Processed: App\Jobs\SampleJob
        ```
      - データベースの確認
        ```plain
        mysql > SELECT * FROM jobs;
        Empty set (0.00 sec)
        ```
        `jobs`テーブルが空になっている


1. Queueを使ってメールを送信する
  新規ユーザーの登録の際に他のユーザー全体にメールを出すと，非常に長い時間がかかってしまう
  それを解消するために，メールの送信をQueueを使って非同期処理にする
    - メールの送信にQueueを使う
      メールの送信に`send`ではなく`queue`を使うと即時にメールを送信するかわりにメールの送信を行うJobをQueueに積むことができる
      `app/Mail/NewUserIntroduction.php`
      ```php
      <?php
      
      namespace App\Mail;

      use App\Models\User;
      use Illuminate\Bus\Queueable;
      use Illuminate\Contracts\Queue\ShouldQueue;
      use Illuminate\Mail\Mailable;
      use Illuminate\Queue\SerializesModels;

      class NewUserIntroduction extends Mailable implements ShouldQueue
      {
        use Queueable, SerializesModels;

        public $subject = '新しいユーザーが追加されました！';
        public User $toUser;
        public User $newUser;

        /**
         * Create a new message instance.
         * @return void
         */
        public function __construct(User $toUser, User $newUser)
        {
          $this->toUser = $toUser;
          $this->newUser = $newUser;
        }

        /**
         * Build the message.
         * 
         * @return $this
         */
        public function build()
        {
          return $this->markdown('email.new_user_introduction');
        }
      }
      ```

      `ShouldQueue`インターフェイスを実装するとQueueに入れるべきだという印を付けることができる
      `ShouldQueue`インターフェイスはメソッドを何も持たないので，`implements ShouldQueue`とするだけでよい

      `artisan queue:work`を実行した状態で新規ユーザーを登録するとメールが非同期に送信される
      ```plain
      $ artisan queue:work
      [YYYY-MM-DD hh:mm:ss][1] Processing: App\Jobs\NewUserIntroduction
      [YYYY-MM-DD hh:mm:ss][1] Processed: App\Jobs\NewUserIntroduction
      ...
      ```
