### PR TITLE
Chapter4-04 画像のアップロード機能を追加する

### DIFF
--- a/app/Http/Controllers/Tweet/CreateController.php
+++ b/app/Http/Controllers/Tweet/CreateController.php
@@ -5,22 +5,24 @@ namespace App\Http\Controllers\Tweet;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Tweet\CreateRequest;
 use App\Models\Tweet;
+use App\Services\TweetService;
 
 class CreateController extends Controller
 {
     /**
      * Handle the incoming request.
      *
-     * @param  \Illuminate\Http\CreateRequest  $request
+     * @param \App\Http\Requests\Tweet\CreateRequest  $request
+     * @param \App\Services\TweetService  $tweetService
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(CreateRequest $request)
+    public function __invoke(CreateRequest $request, TweetService $tweetService)
     {
-        $tweet = new Tweet;
-        $tweet->user_id = $request->userId();
-        $tweet->content = $request->tweet();
-        $tweet->save();
-
+        $tweetService->saveTweet(
+            $request->userId(),
+            $request->tweet(),
+            $request->images()
+        );
         return redirect()->route('tweet.index');
     }
 }

--- a/app/Http/Controllers/Tweet/DeleteController.php
+++ b/app/Http/Controllers/Tweet/DeleteController.php
@@ -24,8 +24,7 @@ class DeleteController extends Controller
             throw new AccessDeniedHttpException();
         }
 
-        $tweet = Tweet::where('id', $tweetId)->firstOrFail();
-        $tweet->delete();
+        $tweetService->deleteTweet($tweetId);
 
         return redirect()
             ->route('tweet.index')

--- a/app/Http/Controllers/Tweet/IndexController.php
+++ b/app/Http/Controllers/Tweet/IndexController.php
@@ -13,15 +13,15 @@ class IndexController extends Controller
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Services\TweetSerice  $tweetService
+     * @param  \App\Services\TweetService  $tweetService
      * @return \Illuminate\Http\Response
      */
     public function __invoke(Request $request, TweetService $tweetService)
     {
-        // TweetServiceのインスタンスを作成
-        //$tweetService = new TweetService();
         // つぶやきの一覧を取得
         $tweets = $tweetService->getTweets();
+        //dump($tweets);
+        //app(\App\Exceptions\Handler::class)->render(request(), throw new \Error('dump report.'));
         return view('tweet.index')
             ->with('tweets', $tweets);
     }

--- a/app/Http/Requests/Tweet/CreateRequest.php
+++ b/app/Http/Requests/Tweet/CreateRequest.php
@@ -24,7 +24,9 @@ class CreateRequest extends FormRequest
     public function rules()
     {
         return [
-            'tweet' => 'required|max:140'
+            'tweet' => 'required|max:140',
+            'images' => 'array|max:4',
+            'images.*' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
         ];
     }
 
@@ -46,5 +48,15 @@ class CreateRequest extends FormRequest
     public function tweet(): string
     {
         return $this->input('tweet');
+    }
+
+    /**
+     * Retrieve the images in the request.
+     * 
+     * @return array
+     */
+    public function images(): array
+    {
+        return $this->file('images', []);
     }
 }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Image extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Tweet.php
+++ b/app/Models/Tweet.php
@@ -9,29 +9,14 @@ class Tweet extends Model
 {
     use HasFactory;
 
-    // テーブルが命名規則に基づかない場合は紐づけが必要
-    // 命名規則: テーブル名はクラス名のスネークケースかつ複数形
-    // protected $table = 'tweet';
-
-    // 主キーが`id`出ない場合は変更する必要がある
-    // protected $primaryKey = 'tweet_id';
-
-    // 主キーが増分整数(AUTO INCREMENT)でない場合はそれを宣言しておく
-    // (UUIDなどを使う場合)
-    // public $incrementing = false;
-
-    // 主キーが整数でない場合はその型も指定する
-    // protected $keyType = 'string';
-
-    // タイムスタンプ(`created_at`，`updated_at`)が不要ならばそれを宣言しておく
-    // public $timestamps = false;
-
-    // `created_at`や`updated_at`のカラム名が異なる場合は指定する
-    // const CREATED_AT = 'creation_date';
-    // const UPDATED_AT = 'updated_date';
-
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function images()
+    {
+        return $this->belongsToMany(Image::class, 'tweet_images')
+            ->using(TweetImage::class);
     }
 }

--- a/app/Models/TweetImage.php
+++ b/app/Models/TweetImage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class TweetImage extends Pivot
+{
+    //
+}

--- a/app/Services/TweetService.php
+++ b/app/Services/TweetService.php
@@ -3,7 +3,10 @@
 namespace App\Services;
 
 use App\Models\Tweet;
+use App\Models\Image;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 class TweetService
 {
@@ -30,5 +33,22 @@ class TweetService
       ->whereDate('created_at', '<',
       Carbon::today()->toDateTimeString())
       ->count();
+  }
+
+  public function saveTweet(int $userId, string $content, array $images)
+  {
+    DB::transaction(function () use ($userId, $content, $images) {
+      $tweet = new Tweet;
+      $tweet->user_id = $userId;
+      $tweet->content = $content;
+      $tweet->save();
+      foreach ($images as $image) {
+        Storage::putFile('public/images', $image);
+        $imageModel = new Image();
+        $imageModel->name = $image->hashName();
+        $imageModel->save();
+        $tweet->images()->attach($imageModel->id);
+      }
+    });
   }
 }

--- a/app/Services/TweetService.php
+++ b/app/Services/TweetService.php
@@ -51,4 +51,21 @@ class TweetService
       }
     });
   }
+
+  public function deleteTweet(int $tweetId)
+  {
+    DB::transaction(function () use ($tweetId) {
+      $tweet = Tweet::where('id', $tweetId)->firstOrFail();
+      $tweet->images()->each(function ($image) use ($tweet) {
+        $filePath = 'public/images/' . $image->name;
+        if (Storage::exists($filePath)) {
+          Storage::delete($filePath);
+        }
+        $tweet->images()->detach($image->id);
+        $image->delete();
+      });
+
+      $tweet->delete();
+    });
+  }
 }

--- a/app/Services/TweetService.php
+++ b/app/Services/TweetService.php
@@ -9,7 +9,7 @@ class TweetService
 {
   public function getTweets()
   {
-    return Tweet::orderBy('created_at', 'DESC')->get();
+    return Tweet::with('images')->orderBy('created_at', 'DESC')->get();
   }
 
   // 自分のtweetかどうかをチェックするメソッド

--- a/database/factories/ImageFactory.php
+++ b/database/factories/ImageFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Image>
+ */
+class ImageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        // ディレクトリがなければ作成する
+        if (!Storage::exists('public/images')) {
+            Storage::makeDirectory('public/images');
+        }
+        return [
+            'name' => $this->faker->image(storage_path('app/public/images'), 640, 480, null, false)
+        ];
+    }
+}

--- a/database/migrations/2024_01_02_181618_create_images_table.php
+++ b/database/migrations/2024_01_02_181618_create_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('images');
+    }
+};

--- a/database/migrations/2024_01_02_181651_create_tweet_images_table.php
+++ b/database/migrations/2024_01_02_181651_create_tweet_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tweet_images', function (Blueprint $table) {
+            $table->foreignId('tweet_id')->constrained('tweets')->cascadeOnDelete();
+            $table->foreignId('image_id')->constrained('images')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tweet_images');
+    }
+};

--- a/database/seeders/TweetsSeeder.php
+++ b/database/seeders/TweetsSeeder.php
@@ -4,9 +4,8 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-//use Illuminate\Support\Facades\DB;
-//use Illuminate\Support\Str;
 use App\Models\Tweet;
+use App\Models\Image;
 
 class TweetsSeeder extends Seeder
 {
@@ -17,11 +16,10 @@ class TweetsSeeder extends Seeder
      */
     public function run()
     {
-        //DB::table('tweets')->insert([
-        //    'content' => Str::random(100),
-        //    'created_at' => now(),
-        //    'updated_at' => now(),
-        //]);
-        Tweet::factory()->count(10)->create();
+        Tweet::factory()->count(10)->create()->each(fn($tweet) =>
+            Image::factory()->count(4)->create()->each(fn($image) =>
+                $tweet->images()->attach($image->id)
+            )
+        );
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,7 @@
 require('./bootstrap');
 
-//import Alpine from 'alpinejs';
+import Alpine from 'alpinejs';
 
-//window.Alpine = Alpine;
+window.Alpine = Alpine;
 
-//Alpine.start();
+Alpine.start();

--- a/resources/views/components/tweet/form/images.blade.php
+++ b/resources/views/components/tweet/form/images.blade.php
@@ -1,0 +1,40 @@
+<script>
+  function inputFormHandler() {
+    return {
+      fields: [],
+      addField() {
+        const i = this.fields.length;
+        this.fields.push({
+          file: '',
+          id: `input-image-${i}`
+        });
+      },
+      removeField(index) {
+        this.fields.splice(index, 1);
+      }
+    }
+  }
+</script>
+<div x-data="inputFormHandler()" class="my-2">
+  <template x-for="(field, i) in fields" :key="i">
+    <div class="w-full flex my-2">
+      <label :for="field.id" class="border border-gray-300 rounded-md p-2 w-full bg-white cursor-pointer">
+        <input type="file" accept="image/*" class="sr-only" :id="field.id" name="images[]" @change="fields[i].file = $event.target.files[0]">
+        <span x-text="field.file ? field.file.name : '画像を選択'" class="text-gray-700"></span>
+        <button type="reset" @click="removeField(i)" class="p-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500 hover:text-red-700" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </label>
+    </div>
+  </template>
+  <template x-if="fields.length < 4">
+    <button type="button" @click="addField()" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-500 hover:bg-gray-600">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+      </svg>
+      <span>画像を追加</span>
+    </button>
+  </template>
+</div>

--- a/resources/views/components/tweet/form/post.blade.php
+++ b/resources/views/components/tweet/form/post.blade.php
@@ -1,6 +1,6 @@
 @auth
 <div class="p-4">
-  <form action="{{ route('tweet.create') }}" method="post">
+  <form action="{{ route('tweet.create') }}" method="post" enctype="multipart/form-data">
     @csrf
     <div class="mt-1">
       <textarea
@@ -12,6 +12,7 @@
     <p class="mt-2 text-sm text-gray-500">
       140文字まで
     </p>
+    <x-tweet.form.images></x-tweet.form.images>
 
     @error('tweet')
     <x-alert.error>{{ $message }}</x-alert.error>

--- a/resources/views/components/tweet/images.blade.php
+++ b/resources/views/components/tweet/images.blade.php
@@ -1,0 +1,54 @@
+@props([
+  'images' => []
+])
+
+@if(count($images) > 0)
+<div x-data="{}" class="px-2">
+  <div class="flex justify-center -mx-2">
+    @foreach($images as $image)
+    <div class="w-1/6 px-2 mt-5">
+      <div class="bg-gray-400">
+        <a @click="$dispatch('img-modal', { imgModalSrc: '{{ asset('storage/images/' . $image->name) }}' })" class="cursor-pointer">
+          <img alt="{{ $image->name }}" class="object-fit w-full" src="{{ asset('storage/images/' . $image->name) }}">
+        </a>
+      </div>
+    </div>
+    @endforeach
+  </div>
+</div>
+@endif
+
+@once
+<div x-data="{ imgModal: false, imgModalSrc: '' }">
+  <div
+    @img-modal.window="imgModal = true; imgModalSrc = $event.detail.imgModalSrc;"
+    x-cloak
+    x-show="imgModal"
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="opacity-0 transform"
+    x-transition:enter-end="opacity-100 transform"
+    x-transition:leave="transition ease-in duration-300"
+    x-transition:leave-start="opacity-100 transform"
+    x-transition:leave-end="opacity-0 transform"
+    x-on:click.away="imgModalSrc = ''"
+    class="p-2 fixed w-full h-100 inset-0 z-50 overflow-hidden flex justify-center items-center bg-black bg-opacity-75">
+    <div @click.away="imgModal = ''" class="flex flex-col max-w-3xl max-h-full overflow-auto">
+      <div class="z-50">
+        <button @click="imgModal = ''" class="float-right pt-2 pr-2 outline-none focus:outline-none">
+          <svg class="fill-current text-white h-5 w-5" xmlns="http://w3.org/200/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
+        </button>
+      </div>
+      <div class="p-2">
+        <img class="object-contain h-1/2-screen" :alt="imgModalSrc" :src="imgModalSrc">
+      </div>
+    </div>
+  </div>
+  @push('css')
+  <style>
+    [x-cloak] { display: none !important; }
+  </style>
+  @endpush
+</div>
+@endonce

--- a/resources/views/components/tweet/list.blade.php
+++ b/resources/views/components/tweet/list.blade.php
@@ -8,9 +8,9 @@
       <div>
         <span class="inline-block rounded-full text-gray-600 bg-gray-100 px-2 py-1 text-xs mb-2">{{ $tweet->user->name }}</span>
         <p class="text-gray-600">{!! nl2br(e($tweet->content)) !!}</p>
+        <x-tweet.images :images="$tweet->images" />
       </div>
       <div>
-        <!-- TODO 編集と削除 -->
         <x-tweet.options :tweetId="$tweet->id" :userId="$tweet->user->id"></x-tweet.options>
       </div>
     </li>


### PR DESCRIPTION
1. 画像投稿機能を実装しよう
    実装する画像投稿機能の仕様は以下の通り
    > 1. つぶやき投稿と共に画像を4枚まで投稿できる
    > 1. 投稿した画像は編集や単体での削除はできない
    > 1. つぶやきを削除すると画像も削除される

    これらを実装するために以下のような処理を実装する
    > 1. ブラウザから投稿された画像を特定のパス(ディレクトリ)に格納する
    > 1. データベースに画像を格納したパスを記録する

    さらに，必要であればサムネイル画像を生成して格納する機能なども考えられる

    - 画像用のテーブルを作成する
      `artisan make:migration createImagesTable`として，画像ファイルへのパスを格納するテーブル`images`を生成する
      - `name`カラムに画像ファイルへのパスが格納される
      - `database/migrations/yyyy_mm_dd_xxxxxx_create_images_table.php`
        ```php
        <?php

        use Illuminate\Database\Migrations\Migration;
        use Illuminate\Database\Schema\Blueprint;
        use Illuminate\Suport\Facades\Schema;

        return new class extends Migration
        {
          /**
           * Run the migrations.
           * 
           * @return void
           */
          public function up()
          {
            Schema::create('images', function (Blueprint $table) {
              $table->id();
              $table->string('name');
              $table->timestamps();
            });
          }

          /**
           * Reverse the migrations.
           * 
           * @return void
           */
          public function down()
          {
            Schema::dropIfExists('images');
          }
        }
        ```

      つぶやきと画像は1対多の関係にあるので交差テーブル(関連テーブル)を作成する必要がある
      `artisan make:migration createTweetImagesTable`として，交差テーブル`tweet_images`を生成する
      - `foreignId`はリレーショナル・データベースにおける外部キーを意味し，`unsignedBigInteger`とエイリアスになっている
      - `constrained`と宣言すると外部キー制約になる
      - 従って，`$table->foreignId('tweet_id')->constrained('tweets')`は`tweets`テーブル内に存在するIDのみ格納できるカラムになる
      - `cascadeOnDelete`は外部キー制約の元のレコードが削除された際に，このテーブルの当該レコードも削除するよう定義している
      - 今回は，`tweets`テーブルで関連付けされているIDのレコードが削除されると，外部キー制約されている`tweet_images`テーブルのレコードも削除される
      - `database/migrations/yyyy_mm_dd_xxxxxx_create_tweet_images_table.php`
        ```php
        <?php

        use Illuminate\Database\Migrations\Migration;
        use Illuminate\Database\Schema\Blueprint;
        use Illuminate\Suport\Facades\Schema;

        return new class extends Migration
        {
          /**
           * Run the migrations.
           * 
           * @return void
           */
          public function up()
          {
            Schema::create('tweet_images', function (Blueprint $table) {
              $table->foreignId('tweet_id')->constrained('tweets')->cascadeOnDelete();
              $table->foreignId('image_id')->constrained('images')->cascadeOnDelete();
              $table->timestamps();
            });
          }

          /**
           * Reverse the migrations.
           * 
           * @return void
           */
          public function down()
          {
            Schema::dropIfExists('tweet_images');
          }
        }
        ```

      最後に`artisan migrate`でマイグレーションを実行する

    - 画像用のEloquentモデルを作成する
      1. `artisan make:model Image -f`で画像用のEloquentモデル`Image`を生成する
        `-f`オプションを渡すことでFactoryも同時に生成する
      1. さらに，`artisan make:model TweetImage --pivot`で交差テーブル用のモデルも生成する
        `--pivot`オプションを渡すことで交差テーブル用のモデルになる
        交差テーブル用のEloquentモデルは`Illuminate\Database\Eloquent\Relations\Pivot`を継承する

      開発用に画像データのFactoryクラスからFakerを利用してダミー画像を生成するように修正する
      画像は`storage/app/public/images`以下に格納される
      - `database/factories/ImageFactory.php`
        ```php
        <?php

        namespace Database\Factories;

        use Illuminate\Database\Eloquent\Factories\Factory;
        use Illuminate\Support\Facades\Storage;

        class ImageFactory extends Factory
        {
          /**
           * Define the model's default state.
           * 
           * @return array
           */
          public function definition()
          {
            // ディレクトリがなければ作成する
            if (!Storage::exists('public/images')) {
              Storage::makeDirectory('public/images');
            }
            return [
              'name' => $this->faker->image(storage_path('app/public/images'), 640, 480, null, false)
            ];
          }
        }
        ```

      このままでは，`storage/app/public/images`が外部からアクセスできないため，`public`から参照できるようにシンボリックリンクを作成する
      - ［`artisan`コマンド］ `storage:link`
        `artisan storage:link`
        `storage`ディレクトリへのシンボリックリンクを`public`ディレクトリに作成する
        `/public/storage <-- /storage/app/public`

      次に`Tweet`モデルから交差テーブルを利用して`Image`モデルとの関連付けを定義する
      この定義では多対多の関連だが，今回は1対多と同義である
      (1つの画像が複数のつぶやきと関連することはない)
      - `app/Models/Tweet.php`
        ```php
        // ...
        class Tweet extends Model
        {
          use HasFactory;

          public function user()
          {
            return $this->belongsTo(User::class);
          }

          public function images()
          {
            return $this->belongsToMany(Image::class, 'tweet_images')
              ->using(TweetImage::class);
          }
        }
        ```

      Seederを修正してつぶやきに関連付けられた画像がシーディングされるようにする
      - `database/seeders/TweetsSeeder.php`
        ```php
        <?php

        namespace Database\Seeders;

        // ...

        use App\Models\Tweet;
        use App\Models\Image;

        // ...
          public function run()
          {
            Tweet::factory()->count(10)->create()->each(fn($tweet) =>
              Image::factory()->count(4)->create()->each(fn($image) =>
                $tweet->images()->attach($image->id)
              )
            );
          }
        // ...
        ```

      最後に`artisan db::seed --class=TweetsSeeder`としてシーディングを実行する

1. つぶやき一覧に画像を表示する
  つぶやき一覧取得処理で，つぶやきに対応する画像も一緒に取得するよう修正する
  `with`メソッドを使うと1+N問題を回避した上で画像もまとめて取得できる(Eager Loading)
    - `app/Services/TweetService.php`
      ```php
      class TweetService
      {
        public function getTweets()
        {
          return Tweet::with('images')->orderBy('created_at', 'DESC')->get();
        }
      }
      ```

    `IndexController`にデバッグ用の`dump`を仕込んで確かめる
    - `app/Http/Controllers/Tweet/IndexController.php`
      ```php
      // ...
      $tweets = $tweetService->getTweets();
      dump($tweet);
      app(\App\Exceptions\Handler::class)->render(request(), throw new \Error('dump report.'));
      return view('tweet.index')
        ->with('tweets', $tweets);
      // ...
      ```
    
    ブラウザからアクセスしてみて，ヘッダのDEBUGからDUMPSタブを開いて`dump`で出力した変数の中身を確認する
    QUERIESタブを開くとSQLは2回しか実行されていないことがわかる

    - フロントエンドの作成
      Alpine.jsを利用して画像の拡大表示を実装する
      まず，画像の表示を行うコンポーネントを作成する
      `$images`で画像の配列を受け取る
      `@if(count($images) > 0)`により，画像の投稿が1つ以上ある場合に表示する
      `@click`はAlpine.jsのディレクティブで`x-on:click`のシンタックスシュガーである
      これはクリックイベントに関数を登録できるので，`$dispatch`関数を利用して`img-modal`を起動させる
      - `resources/views/components/tweet/images.blade.php`
        ```php
        @props([
          'images' => []
        ])

        @if(count($images) > 0)
        <div x-data="{}" class="px-2">
          <div class="flex justify-center -mx-2">
            @foreach($images as $image)
            <div class="w-1/6 px-2 mt-5">
              <div class="bg-gray-400">
                <a @click="$dispatch('img-modal', { imgModalSrc: '{{ asset('storage/images/' . $image->name) }}' })" class="cursor-pointer">
                  <img alt="{{ $image->name }}" class="object-fit w-full" src="{{ asset('storage/images/' . $image->name) }}">
                </a>
              </div>
            </div>
            @endforeach
          </div>
        </div>
        @endif

        @once
        <div x-data="{ imgModal: false, imgModalSrc: '' }">
          <div @img-modal.window="imgModal = true; imgModalSrc = $event.detail.imgModalSrc;"
            x-cloak
            x-show="img-Modal"
            x-transition:enter="transition ease-out duration-300"
            x-transition:enter-start="opacity-0 transform"
            x-transition:enter-end="opacity-100 transform"
            x-transition:leave="transition ease-in duration-300"
            x-transition:leave-start="opacity-100 transform"
            x-transition:leave-end="opacity-0 transform"
            x-on:click.away="imgModalSrc = ''"
            class="p-2 fixed w-full h-100 inset-0 z-50 overflow-hidden flex justify-center items-center bg-black bg-opacity-75">
            <div @click.away="imgModal = ''" class="flex flex-col max-w-3xl max-h-full overflow-auto">
              <div class="z-50">
                <button @click="imgModal = ''" class="float-right pt-2 pr-2 outline-none focus:outline-none">
                  <svg class="fill-current text-white h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                    <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
                  </svg>
                </button>
              </div>
              <div class="p-2">
                <img
                  class="object-contain h-1/2-screen"
                  :alt="imgModalSrc"
                  :src="imgModalSrc">
              </div>
            </div>
          </div>
        </div>
        @push('css')
        <style>
            [x-cloak] { display: none !important; }
        </style>
        @endpush
        @endconce
        ```

      このコンポーネントをつぶやき一覧から呼び出す
      - `resources/views/components/tweet/list.blade.php`
        ```php
        @props([
          'tweets' => []
        ])
        <div class="bg-white rounded-md shadow-lg mt-5 mb-5">
          <ul>
            @foreach($tweets as $tweet)
            <li class="border-b last:border-b-0 border-gray-200 p-4 flex items-start justify-between">
              <div>
                <span class="inline-block rounded-full text-gray-600 bg-gray-100 px-2 py-1 text-xs mb-2">
                  {{ $tweet->user->name }}
                </span>
                <p class="text-gray-600">{!! nl2br(e($tweet->content)) !!}</p>
                <x-tweet.images :images="$tweet->images" />
              </div>
              <div>
                <x-tweet.options :tweetId="$tweet->id" :userId="$tweet->user_id"></x-tweet.options>
              </div>
            </li>
            @endforeach
          </ul>
        </div>
        ```
      
      CSSを反映させるため`npm run development`する

1. 画像投稿処理を作成する
    つぶやき投稿時に画像も一緒に投稿できるように機能を追加する

    - 画像のバリデーション
      `CreateRequest`クラスにバリデーション定義を追加する
      `rules`に`images`と`images.*`を追加した
      `images`には画像投稿は必須ではないが最大4件までなので`array|max:4`を指定する
      `images`の各項目についてのバリデーションは`images.*`で定義する
      `images.*`は画像であり最大サイズが2MBなので`required|image|mimes:jpeg,png,jpg,gif|max:2048`と指定する
      (画像に対する最大サイズはKB単位で指定する)
      画像の取得はファイル投稿なので，`$this->file`から取得する(`$this->input`ではない)
      - `app/Http/Requests/Tweet/CreateRequest.php`
        ```php
        // ...
        class CreateRequest extends FormRequest
        {
          // ...
          public function rules()
          {
            return [
              'tweet' => 'required|max:140',
              'images' => 'array|max:4',
              'images.*' => 'required|image|mimes:jpg,png,jpg,gif|max:2048'
            ];
          }
          // ...
          public function images(): array
          {
            return $this->file('images', []);
          }
        }
        ```

    - つぶやきと画像を一緒に保存する仕組みを作る
      画像を含めたつぶやきの保存処理はサービスクラスに実装する
      (このままコントローラに実装するとコントローラーが肥大化する)
      DBファサードを利用してトランザクションを管理する
      つぶやきの保存と画像の保存をトランザクションにｍたおめる
      `use()`は関数外で定義した変数を参照する際に利用する
      - `app/Services/TweetService.php`
        ```php
        <?php

        namespace App\Services;

        use App\Models\Tweet;
        use Carbon\Carbon;
        use App\Models\Image;
        use Illuminate\Support\Facades\DB;
        use Illuminate\Support\Facades\Storage;

        // ...
          public function saveTweet(int $userId, string $content, array $images)
          {
            DB::transaction(function () use ($userId, $content, $images) {
              $tweet = new Tweet;
              $tweet->id = $user_id;
              $tweet->content = $content;
              $tweet->save();
              foreach ($images as $image) {
                Storage::putFile('public/images', $image);
                $imageModel = new Image();
                $imageModel->name = $image->hashName();
                $imageModel->save();
                $tweet->images()->attach($imageModel->id);
              }
            });
          }
          // ...
        ```

    - 画像を実際に保存する
      つぶやきをテーブルに永続化した後，以下のように画像を1枚ずつ保存する
      > 1. 画像の名前をランダムに生成
      > 1. `storage/images`ディレクトリに上で生成した名前で画像ファイルを保存
      > 1. Eloquentモデルに格納先のパスと画像のファイル名を指定して永続化
      > 1. `Tweet`モデルを経由してつぶやきと画像の交差テーブルにデータを永続化

      コントローラからサービスクラスを利用して保存するよう修正する
      - `app/Http/Controllers/Tweet/CreateController.php`
        ```php
        <?php

        namespace App\Http\Controllers\Tweet;

        use App\Http\Controllers\Controller;
        use App\Http\Requests\Tweet\CreateRequest;
        use App\Models\Tweet;
        use App\Services\TweetService;

        class CreateController extends Controller
        {
          // ...

          public function __invoke(CreateRequest $request, TweetService $tweetService)
          {
            $tweetService->saveTweet(
              $request->userId(),
              $request->tweet(),
              $request->images()
            );
            return redirect()->route('tweet.index');
          }
        }
        ```

    - フロントエンドを変更する
      画像を投稿するフォームコンポーネントを作成する
      - `resources/views/components/tweet/form/images.blade.php`
        ```php
        <div x-data="inputFormHandler()" class="my-2">
          <template x-for="(field, i) in fields" :key="i">
            <div class="w-full flex my-2">
              <label :for="field.id" class="border border-gray-300 rounded-md p-2 w-full bg-white cursor-pointer">
                <input type="file" accept="image/*" class="sr-only" :id="field.id" name="images[]" @change="fields[i].file = $event.target.files[0]">
                <span x-text="field.file ? field.file.name : '画像を選択'" class="text-gray-700"></span>
              </label>
              <button type="reset" @click="removeField(i)" class="p-2">
                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-red-500 hover:text-red-700" viewBox="0 0 20 20" fill="currentColor">
                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
                </svg>
              </button>
            </div>
          </template>

          <template x-if="fields.length < 4">
            <button type="button" @click="addField()" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-500 hover:bg-gray-600">
              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
                <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
              </svg>
              <span>画像を追加</span>
            </button>
          </template>
        </div>

        <script>
        function inputFormHandler() {
          return {
            fields: [],
            addField() {
              const i = this.fields.length;
              this.fields.push({
                file: '',
                id: `input-image-${i}`
              });
            },
            removeField(index) {
              this.fields.splice(index, 1)
            }
          }
        }
        </script>
        ```

      - `resources/views/components/tweet/form/post.blade.php`
        ```php
        @auth
        <div class="p-4">
          <form action="{{ route('tweet.create') }}" method="post" enctype="multipart/form-data">
            @csrf
            <div class="m-1">
              <textarea name="tweet" rows="3" classs="focus:ring-blue-400 focus:border-blue-400 mt-1 block w-full sm:text-sm border border-gray-300 rounded-md p-2" placeholder="つぶやきを入力"></textarea>
            </div>
            <p class="mt-2 text-sm text-gray-500">
              140文字まで
            </p>
            <x-tweet.form.images></x-tweet.form.images>

            @error('tweet')
            <x-alert.error>{{ $message }}</x-alert.error>
            @enderror

            // ...
          </form>
        </div>

        // ...
        @endauth
        ```

1. 削除処理を実装する
    つぶやきの削除時に画像も一緒に削除されるようにする
    実装はサービスクラスに行う
    > 1. 対象のつぶやきモデルを取得
    > 1. つぶやきモデルに関連付けられている画像を1件ずつ参照
    > 1. 画像モデルからファイルパスを作成し，`File`クラス(ファサード)を利用して画像の実体を確認
    > 1. 画像があれば削除
    > 1. つぶやきと画像の関連付けを`detach`で削除
    > 1. 画像モデル(レコード)を削除

    - `app/Services/TweetService.php`
      ```php
      // ...
      class TweetService
      {
        // ...
        public function deleteTweet(int $tweedId)
        {
          DB::transaction(function () use ($tweetId) {
            $tweet = Tweet::where('id', $tweetId)->firstOrFail();
            $tweet->images()->each(function ($image) use ($tweet) {
              $filePath = 'public/images/' . $image->name;
              if (Storage::exists($filePath) {
                Storage::delete($filePath);
              })
              $tweet->images()->detach($image->id);
              $image->delete();
            });

            $tweet->delete();
          });
        }
      }
      ```

    投稿処理と同様にコントローラからサービスクラスを呼び出して処理を行う

    - `app/Http/Controllers/Tweet/DeleteController.php`
      ```php
      // ...
      class DeleteController extends Controller
      {
        // ...
        public function __invoke(Request $request, TweetService $tweetService)
        {
          $tweetId = (int) $request->route('tweetId');
          if (!$tweetService->checkOwnTweet($request->user()->id, $tweetId)) {
            throw new AccessDeniedHttpException();
          }
          $tweetService->deleteTweet($tweetId);
          return redirect()
            ->route('tweet.index')
            ->with('feedback.success', "つぶやきを削除しました");
        }
      }
      ```

    実際にブラウザから画像付きで投稿したつぶやきを削除すると`storage/app/public/images`ディレクトリから対象の画像が削除される
